### PR TITLE
crash on insert, disappearing header / footer

### DIFF
--- a/UICollectionView-Spring-Demo/TLSpringFlowLayout.m
+++ b/UICollectionView-Spring-Demo/TLSpringFlowLayout.m
@@ -184,6 +184,11 @@
     
     [updateItems enumerateObjectsUsingBlock:^(UICollectionViewUpdateItem *updateItem, NSUInteger idx, BOOL *stop) {
         if (updateItem.updateAction == UICollectionUpdateActionInsert) {
+            if([self.dynamicAnimator layoutAttributesForCellAtIndexPath:updateItem.indexPathAfterUpdate])
+            {
+                return;
+            }
+            
             UICollectionViewLayoutAttributes *attributes = [UICollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:updateItem.indexPathAfterUpdate];
             
             //attributes.frame = CGRectMake(10, updateItem.indexPathAfterUpdate.item * 310, 300, 44); // or some other initial frame


### PR DESCRIPTION
This fixes two issues.

1) there is a crash when inserting cells if you are trying to reuse a UIAttachmentBehavior if its already in the dynamic animator

2) if you have headers or footers they will disappear once scrolled out of view, but since headers and footer share the same index path as the first and last item they wont reappear consistently.  Added a set just for headers and footers.
